### PR TITLE
Fixed undefined error in poem.js when line greater than array length.

### DIFF
--- a/poem.js
+++ b/poem.js
@@ -6,6 +6,7 @@ function nextLine(line) {
 "<p onClick=nextLine(4)>Now they all send <em>me</em> changes, d'oh!</p>",
 "<p onClick=nextLine(5)>Said the maintainer, 'Welcome to the club!'</p>");
 
+	line = line % poem.length;
 	document.getElementById("line").innerHTML=poem[line];
 }
 


### PR DESCRIPTION
When using the interactive poem if the line passed to the function is greater than the length of the array you get undefined. I added a line to use modulo to keep the line within the bounds of the array length.
